### PR TITLE
fix(build): use better signing configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,8 @@ android {
 
   signingConfigs {
     create("release") {
+      enableV3Signing = true
+      enableV4Signing = true
       val keystorePath = System.getenv("KEYSTORE_PATH")
       if (keystorePath != null) {
         storeFile = file(keystorePath)

--- a/scripts/setup-signing.sh
+++ b/scripts/setup-signing.sh
@@ -8,8 +8,8 @@ echo "You can use it both for local signing and for GitHub Actions CI."
 echo ""
 
 read -r -p "Keystore password: " -s STORE_PASS
-echo ""
-read -r -p "Key password (same as keystore or different): " -s KEY_PASS
+# Different key passwords are ignored
+KEY_PASS="$STORE_PASS"
 echo ""
 read -r -p "Key alias [wheelwitch]: " KEY_ALIAS
 KEY_ALIAS=${KEY_ALIAS:-wheelwitch}
@@ -27,9 +27,11 @@ C=${C:-US}
 
 keytool -genkey -v \
   -keystore "$OUTPUT" \
+  -storetype pkcs12 \
   -alias "$KEY_ALIAS" \
   -keyalg RSA \
-  -keysize 2048 \
+  -keysize 4096 \
+  -sigalg SHA512withRSA \
   -validity 10000 \
   -storepass "$STORE_PASS" \
   -keypass "$KEY_PASS" \


### PR DESCRIPTION
The current keystore configuration for CI builds uses an RSA key size of `2048`, which is rather small by today's standards. Also, only V2 signing seems to be enabled currently, so I changed the signing config to use more modern defaults (enabling V3 and V4 signatures, setting `storetype` and `sigalg`). Note that `KEY_PASS` is expected to be the same password as `STORE_PASS` now.

In my opinion, now would be a good time to use a more secure keystore, since the project is still in its early stages and it would not be a huge problem for users. Also, the SHA hash of the signing certificate could be added to the README for double-checking the hash in AppVerifier.

If you decide to merge this, please also note that V4 signatures have a separate file (`app-release.apk.idsig`) next to the built `app-release.apk`, which would have to be added as a workflow + release artifact to `build.yml` if you want to provide them.