### PR TITLE
fix(save): use correct vanilla `rksys.dat` paths

### DIFF
--- a/app/src/main/java/com/skiletro/wheelwitch/data/DolphinPaths.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/DolphinPaths.kt
@@ -95,17 +95,17 @@ object DolphinPaths {
 
   /**
    * Directory for a vanilla MKW save at
-   * `Wii/title/00010001/<region>/data/`.
+   * `Wii/title/00010004/<regionAsHex>/data/`.
    */
-  fun vanillaSaveDir(context: Context, region: String): File =
-    File(nandTitleDir(context, "00010001"), "$region/data")
+  fun vanillaSaveDir(context: Context, region: SaveManager.Region): File =
+    File(nandTitleDir(context, SaveManager.TITLE_ID), "${region.hexCode()}/data")
 
   /**
    * Directory for a patched-ISO save at
    * `Wii/title/00010004/524d4352/data/`.
    */
   fun patchedIsoSaveDir(context: Context): File =
-    File(nandTitleDir(context, "00010004"), "524d4352/data")
+    File(nandTitleDir(context, SaveManager.TITLE_ID), "${SaveManager.PATCHED_ISO_HEX_ID}/data")
 
   /**
    * The expected SAF tree document id for the Dolphin user folder.

--- a/app/src/main/java/com/skiletro/wheelwitch/data/SaveManager.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/SaveManager.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import timber.log.Timber
+import kotlin.text.startsWith
 
 /**
  * Unified save data backup/restore and per-region helpers for the
@@ -58,17 +59,19 @@ object SaveManager {
     PAL("RMCP"),
     USA("RMCE"),
     JPN("RMCJ"),
-    KOR("RMCK"),
+    KOR("RMCK");
+
+    fun hexCode(): String = code.codePoints().toArray()
+      .joinToString("") { cp ->
+        cp.toString(16).lowercase().padStart(2, '0')
+      }
   }
 
   /** Filename of the save file inside the region directory. */
   const val SAVE_FILE_NAME = "rksys.dat"
 
-  /** Wii title ID for standard retail games (Mario Kart Wii and others). */
-  const val TITLE_ID_RETAIL = "00010001"
-
-  /** Wii title ID for WiiWare / channels (used by patched ISOs). */
-  const val TITLE_ID_PATCHED = "00010004"
+  /** Wii title ID for game channels (also used by patched ISOs). */
+  const val TITLE_ID = "00010004"
 
   /**
    * Hex-encoded game ID for patched Retro Rewind ISOs (`RMCR`).
@@ -207,14 +210,14 @@ object SaveManager {
   /**
    * Searches for existing vanilla save (`rksys.dat`) for every
    * [Region] under the Wii NAND path
-   * `Wii/title/00010001/<region>/data/`. Returns the list of regions
+   * `Wii/title/00010004/<regionAsHex>/data/`. Returns the list of regions
    * whose save was found. Does NOT create any directories — only
    * checks existing paths.
    */
   private fun vanillaSaveFiles(tree: DolphinTree): List<Pair<Region, DocumentFile>> {
     val results = mutableListOf<Pair<Region, DocumentFile>>()
     for (region in Region.entries) {
-      val file = findNandSaveFile(tree.root, TITLE_ID_RETAIL, region.code)
+      val file = findNandSaveFile(tree.root, TITLE_ID, region.hexCode())
       if (file != null) results.add(region to file)
     }
     return results
@@ -226,7 +229,7 @@ object SaveManager {
    * Does NOT create any directories.
    */
   private fun findPatchedIsoSaveFile(tree: DolphinTree): DocumentFile? =
-    findNandSaveFile(tree.root, TITLE_ID_PATCHED, PATCHED_ISO_HEX_ID)
+    findNandSaveFile(tree.root, TITLE_ID, PATCHED_ISO_HEX_ID)
 
   /**
    * Snapshots the per-region Retro Rewind `rksys.dat` files and
@@ -379,7 +382,7 @@ object SaveManager {
             for ((region, file) in availableVanilla) {
               val bytes = readDolphinBytes(tree.resolver, file) ?: continue
               zip.putNextEntry(
-                ZipEntry("Wii/title/$TITLE_ID_RETAIL/${region.code}/data/$SAVE_FILE_NAME").apply {
+                ZipEntry("Wii/title/$TITLE_ID/${region.hexCode()}/data/$SAVE_FILE_NAME").apply {
                   size = bytes.size.toLong()
                 }
               )
@@ -392,7 +395,7 @@ object SaveManager {
               if (bytes != null) {
                 zip.putNextEntry(
                   ZipEntry(
-                    "Wii/title/$TITLE_ID_PATCHED/$PATCHED_ISO_HEX_ID/data/$SAVE_FILE_NAME"
+                    "Wii/title/$TITLE_ID/$PATCHED_ISO_HEX_ID/data/$SAVE_FILE_NAME"
                   ).apply { size = bytes.size.toLong() }
                 )
                 zip.write(bytes)
@@ -542,9 +545,10 @@ object SaveManager {
               writeDolphinBytes(tree.resolver, parent, name, bytes)
               when {
                 entryName.startsWith("RetroWFC/") && name == SAVE_FILE_NAME -> rksys++
-                entryName.startsWith("Wii/title/$TITLE_ID_RETAIL/") &&
+                entryName.startsWith("Wii/title/$TITLE_ID/") &&
+                  !entryName.startsWith("Wii/title/$TITLE_ID/$PATCHED_ISO_HEX_ID/data") &&
                   name == SAVE_FILE_NAME -> vanillaSaves++
-                entryName.startsWith("Wii/title/$TITLE_ID_PATCHED/") &&
+                entryName.startsWith("Wii/title/$TITLE_ID/$PATCHED_ISO_HEX_ID/data") &&
                   name == SAVE_FILE_NAME -> patchedIso = true
                 entryName.startsWith("Wii/shared2/menu/FaceLib/") &&
                   name == UserDataPaths.RFL_DB -> faceLib = true
@@ -644,27 +648,27 @@ object SaveManager {
       val dir = saveDir(tree, region)
       return dir to parts[1]
     }
-    if (normalized.startsWith("Wii/title/$TITLE_ID_RETAIL/")) {
-      // Vanilla save: Wii/title/00010001/<region>/data/<filename>
-      val rest = normalized.removePrefix("Wii/title/$TITLE_ID_RETAIL/")
+    if (normalized.startsWith("Wii/title/$TITLE_ID/")) {
+      if (normalized.startsWith("Wii/title/$TITLE_ID/$PATCHED_ISO_HEX_ID/data")) {
+        // Patched ISO: Wii/title/00010004/524d4352/data/<filename>
+        val rest = normalized.removePrefix("Wii/title/$TITLE_ID/")
+        val parts = rest.split('/').filter { it.isNotEmpty() }
+        if (parts.size != 3 || parts[0] != PATCHED_ISO_HEX_ID || parts[1] != "data") return null
+        val dir =
+          navigateOrCreate(
+            tree.root,
+            listOf("Wii", "title", TITLE_ID, PATCHED_ISO_HEX_ID, "data"),
+          )
+        return dir to parts[2]
+      }
+      // Vanilla save: Wii/title/00010004/<regionAsHex>/data/<filename>
+      val rest = normalized.removePrefix("Wii/title/$TITLE_ID/")
       val parts = rest.split('/').filter { it.isNotEmpty() }
-      if (parts.size != 3 || parts[0].length != 4 || parts[1] != "data") return null
+      if (parts.size != 3 || parts[1] != "data") return null
       val region = parts[0]
-      if (region !in Region.entries.map { it.code }) return null
+      if (region !in Region.entries.map { it.hexCode() }) return null
       val dir =
-        navigateOrCreate(tree.root, listOf("Wii", "title", TITLE_ID_RETAIL, region, "data"))
-      return dir to parts[2]
-    }
-    if (normalized.startsWith("Wii/title/$TITLE_ID_PATCHED/")) {
-      // Patched ISO: Wii/title/00010004/524d4352/data/<filename>
-      val rest = normalized.removePrefix("Wii/title/$TITLE_ID_PATCHED/")
-      val parts = rest.split('/').filter { it.isNotEmpty() }
-      if (parts.size != 3 || parts[0] != PATCHED_ISO_HEX_ID || parts[1] != "data") return null
-      val dir =
-        navigateOrCreate(
-          tree.root,
-          listOf("Wii", "title", TITLE_ID_PATCHED, PATCHED_ISO_HEX_ID, "data"),
-        )
+        navigateOrCreate(tree.root, listOf("Wii", "title", TITLE_ID, region, "data"))
       return dir to parts[2]
     }
     if (normalized.startsWith("Wii/shared2/menu/FaceLib/")) {

--- a/app/src/test/java/com/skiletro/wheelwitch/data/SaveManagerTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/data/SaveManagerTest.kt
@@ -194,7 +194,7 @@ class SaveManagerTest {
     assertThat(result.isSuccess).isTrue()
     val entries = readZipEntries(destOutput.toByteArray())
     val names = entries.map { it.name }
-    assertThat(names).contains("Wii/title/00010001/RMCP/data/rksys.dat")
+    assertThat(names).contains("Wii/title/00010004/524d4350/data/rksys.dat")
     assertThat(names).contains("RetroWFC/RMCP/rksys.dat")
     // Manifest should list vanilla regions.
     val manifest = JSONObject(String(entries.first { it.name == "manifest.json" }.bytes))
@@ -234,7 +234,7 @@ class SaveManagerTest {
     assertThat(result.isSuccess).isTrue()
     val entries = readZipEntries(destOutput.toByteArray())
     val names = entries.map { it.name }
-    assertThat(names).doesNotContain("Wii/title/00010001/RMCP/data/rksys.dat")
+    assertThat(names).doesNotContain("Wii/title/00010004/524d4350/data/rksys.dat")
   }
 
   // --- hasAnySave: vanilla and patched ISO -------------------------------
@@ -384,7 +384,7 @@ class SaveManagerTest {
         zos.putNextEntry(ZipEntry("manifest.json"))
         zos.write(manifest.toString().encodeToByteArray())
         zos.closeEntry()
-        zos.putNextEntry(ZipEntry("Wii/title/00010001/RMCP/data/rksys.dat"))
+        zos.putNextEntry(ZipEntry("Wii/title/00010004/524d4350/data/rksys.dat"))
         zos.write("vanilla-save".encodeToByteArray())
         zos.closeEntry()
       }
@@ -541,7 +541,7 @@ class SaveManagerTest {
         zos.putNextEntry(ZipEntry("Wii/shared2/Pulsar/RetroRewind6/RRRating.pul"))
         zos.write("rating-data".encodeToByteArray())
         zos.closeEntry()
-        zos.putNextEntry(ZipEntry("Wii/title/00010001/RMCP/data/rksys.dat"))
+        zos.putNextEntry(ZipEntry("Wii/title/00010004/524d4350/data/rksys.dat"))
         zos.write("vanilla-data".encodeToByteArray())
         zos.closeEntry()
         zos.putNextEntry(ZipEntry("Wii/shared2/menu/FaceLib/RFL_DB.dat"))
@@ -858,8 +858,8 @@ class SaveManagerTest {
 
     // Vanilla save NAND chain (includeVanillaSaves stubs RMCP for brevity).
     if (includeVanillaSaves) {
-      val titleIdDir = mockDir(SaveManager.TITLE_ID_RETAIL)
-      val regionDir = mockDir(Region.PAL.code)
+      val titleIdDir = mockDir(SaveManager.TITLE_ID)
+      val regionDir = mockDir(Region.PAL.hexCode())
       val dataDir = mockDir("data")
       val saveFile = mockk<DocumentFile>(relaxed = true)
       val saveFileUri = mockk<Uri>(relaxed = true)
@@ -868,10 +868,10 @@ class SaveManagerTest {
       every { saveFile.exists() } returns true
       every { saveFile.isFile } returns true
       every { saveFile.delete() } returns true
-      every { titleDir.findFile(SaveManager.TITLE_ID_RETAIL) } returns titleIdDir
-      every { titleDir.createDirectory(SaveManager.TITLE_ID_RETAIL) } returns titleIdDir
-      every { titleIdDir.findFile(Region.PAL.code) } returns regionDir
-      every { titleIdDir.createDirectory(Region.PAL.code) } returns regionDir
+      every { titleDir.findFile(SaveManager.TITLE_ID) } returns titleIdDir
+      every { titleDir.createDirectory(SaveManager.TITLE_ID) } returns titleIdDir
+      every { titleIdDir.findFile(Region.PAL.hexCode()) } returns regionDir
+      every { titleIdDir.createDirectory(Region.PAL.hexCode()) } returns regionDir
       every { regionDir.findFile("data") } returns dataDir
       every { regionDir.createDirectory("data") } returns dataDir
       every { dataDir.findFile(SaveManager.SAVE_FILE_NAME) } returns saveFile
@@ -880,7 +880,7 @@ class SaveManagerTest {
         ByteArrayInputStream("vanilla-RMCP".encodeToByteArray())
     }
     if (includePatchedIso) {
-      val patchedIdDir = mockDir(SaveManager.TITLE_ID_PATCHED)
+      val patchedIdDir = mockDir(SaveManager.TITLE_ID)
       val patchedRegionDir = mockDir(SaveManager.PATCHED_ISO_HEX_ID)
       val patchedDataDir = mockDir("data")
       val patchedSaveFile = mockk<DocumentFile>(relaxed = true)
@@ -890,8 +890,8 @@ class SaveManagerTest {
       every { patchedSaveFile.exists() } returns true
       every { patchedSaveFile.isFile } returns true
       every { patchedSaveFile.delete() } returns true
-      every { titleDir.findFile(SaveManager.TITLE_ID_PATCHED) } returns patchedIdDir
-      every { titleDir.createDirectory(SaveManager.TITLE_ID_PATCHED) } returns patchedIdDir
+      every { titleDir.findFile(SaveManager.TITLE_ID) } returns patchedIdDir
+      every { titleDir.createDirectory(SaveManager.TITLE_ID) } returns patchedIdDir
       every { patchedIdDir.findFile(SaveManager.PATCHED_ISO_HEX_ID) } returns patchedRegionDir
       every { patchedIdDir.createDirectory(SaveManager.PATCHED_ISO_HEX_ID) } returns patchedRegionDir
       every { patchedRegionDir.findFile("data") } returns patchedDataDir


### PR DESCRIPTION
The vanilla save backup functionality had the incorrect title folder `00010001`, which should have been the same one as was used for the patched ISO saves (`00010004`). Moreover, the subfolders in there are always hex codes, just like `524d4352` -- for this, a function mapping the enum strings to their hex string values was created.

Related issue: #14