### PR TITLE
fix(pack): speed up extraction by caching existing files of directories

### DIFF
--- a/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
@@ -246,6 +246,20 @@ class DolphinTree(context: Context, val treeUri: Uri) {
 
         val byPath: Map<List<String>, DocumentFile> =
           precreateDirectories(fileEntries, onProgress, filesTotal, bytesTotal)
+        val childrenByParentUri = mutableMapOf<Uri, MutableMap<String, DocumentFile>>()
+        val getChild: (DocumentFile, String) -> DocumentFile? = { parent, fileName ->
+          val cachedFiles = childrenByParentUri.getOrPut(parent.uri) {
+            val childrenMap = mutableMapOf<String, DocumentFile>()
+            val children = parent.listFiles()
+            for (child in children) {
+              child.name?.let { childFileName ->
+                childrenMap[childFileName] = child
+              }
+            }
+            childrenMap
+          }
+          cachedFiles[fileName]
+        }
 
         var fileIndex = 0
         var bytesDone = 0L
@@ -265,6 +279,7 @@ class DolphinTree(context: Context, val treeUri: Uri) {
           writeZipEntry(
             entry = entry,
             parent = byPath.getValue(parentParts(entry.name)),
+            getChild = getChild,
             fileName = entry.name.substringAfterLast('/'),
             input = zip.getInputStream(entry),
           )
@@ -529,6 +544,7 @@ class DolphinTree(context: Context, val treeUri: Uri) {
   private fun writeZipEntry(
     entry: ZipEntry,
     parent: DocumentFile,
+    getChild: (DocumentFile, String) -> DocumentFile?,
     fileName: String,
     input: InputStream,
   ) {
@@ -536,7 +552,7 @@ class DolphinTree(context: Context, val treeUri: Uri) {
       Timber.tag(TAG).d("Skipping user data path: %s", entry.name)
       return
     }
-    parent.findFile(fileName)?.delete()
+    getChild(parent, fileName)?.delete()
     val target =
       parent.createFile("application/octet-stream", fileName)
         ?: error("Cannot create ${entry.name} in pack/")

--- a/app/src/test/java/com/skiletro/wheelwitch/data/DolphinTreeTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/data/DolphinTreeTest.kt
@@ -615,17 +615,21 @@ class DolphinTreeTest {
   ) = runBlocking {
     val (_, packDir, _) = setupDirChain()
     val zip = File(tempDir.toFile(), "pack.zip")
+    val fileName = "file1.txt"
+    val fileContent = "hello"
     ZipOutputStream(zip.outputStream()).use { zos ->
-      zos.putNextEntry(ZipEntry("file1.txt"))
-      zos.write("hello".encodeToByteArray())
+      zos.putNextEntry(ZipEntry(fileName))
+      zos.write(fileContent.encodeToByteArray())
       zos.closeEntry()
     }
     val existing = mockk<DocumentFile>(relaxed = true)
     val created = mockk<DocumentFile>(relaxed = true)
     val uri = mockk<Uri>(relaxed = true)
     every { created.uri } returns uri
-    every { packDir.findFile("file1.txt") } returns existing
-    every { packDir.createFile("application/octet-stream", "file1.txt") } returns created
+    every { existing.name } returns fileName
+    every { packDir.listFiles() } returns arrayOf(existing)
+    every { packDir.findFile(fileName) } returns existing
+    every { packDir.createFile("application/octet-stream", fileName) } returns created
     val baos = ByteArrayOutputStream()
     every { resolver.openOutputStream(uri) } returns baos
 
@@ -633,7 +637,7 @@ class DolphinTreeTest {
     tree.extractZipToPack(zip) { /* no-op */ }
 
     verify { existing.delete() }
-    assertThat(baos.toString(Charsets.UTF_8)).isEqualTo("hello")
+    assertThat(baos.toString(Charsets.UTF_8)).isEqualTo(fileContent)
   }
 
   @Test


### PR DESCRIPTION
The regression was caused by commit 3487735, which introduced the delete call before creating the file to ensure no duplicate files are created. What made this change inefficient is the fact that `DocumentFile.findFile` always calls `DocumentFile.listFiles` for every single file that is extracted, which is unnecessary, as many files are in the same directory. We now cache the `DocumentFile.listFiles` results to speed up the extraction.

Closes #17.