### PR TITLE
fix(api): use new badges api endpoint

### DIFF
--- a/app/src/main/java/com/skiletro/wheelwitch/network/VersionFileParser.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/network/VersionFileParser.kt
@@ -78,7 +78,7 @@ object VersionFileParser {
     private const val RACE_STATS_URL = "$RWFC_API/api/racestats/global"
     private const val TIME_TRIAL_TRACKS_URL = "$RWFC_API/api/timetrial/tracks"
     private const val TIME_TRIAL_LEADERBOARD_URL = "$RWFC_API/api/timetrial/leaderboard"
-    private const val BADGES_BASE = "https://update.rwfc.net/RetroRewind/badges/"
+    private const val BADGES_BASE = "$RWFC_API/api/game/badges/"
 
     private val httpClient get() = HttpClientProvider.client
     private val probeClient get() = HttpClientProvider.probeClient


### PR DESCRIPTION
The old endpoint for badges is not available anymore, returning `404` responses. This PR changes the badges API to the correct one.