### PR TITLE
fix(rksys): do not show friend code if `pid` is `0`

### DIFF
--- a/app/src/main/java/com/skiletro/wheelwitch/data/RksysParser.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/RksysParser.kt
@@ -115,7 +115,10 @@ object RksysParser {
    * The checksum is `(md5[0] & 0xFF) >> 1` because the friend-code high
    * byte uses only 7 bits (the top bit is reserved).
    */
-  private fun pidToFriendCode(pid: Long): String {
+  private fun pidToFriendCode(pid: Long): String? {
+    if (pid == 0L) {
+      return null
+    }
     // Layout: PID (LE, 4 bytes) || "JCMR" (ASCII, 4 bytes)
     val buffer = ByteArray(8)
     buffer[0] = (pid and 0xFF).toByte()

--- a/app/src/test/java/com/skiletro/wheelwitch/data/RksysParserTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/data/RksysParserTest.kt
@@ -156,12 +156,25 @@ class RksysParserTest {
   }
 
   @Test
+  fun `parse license null friend code from PID 0`() {
+    val buf = createBuffer()
+    val base = RksysParser.LICENSE_BASES[0]
+    buf.writeAscii(base, "RKPD")
+    // PID = 0 means that the game does not show a friend code
+    buf.writeUInt32BE(base + PID_OFFSET, 0L)
+
+    val info = RksysParser.parse(buf)
+    val friendCode = info.licenses[0].friendCode
+    assertThat(friendCode).isNull()
+  }
+
+  @Test
   fun `parse license correct friend code from PID`() {
     val buf = createBuffer()
     val base = RksysParser.LICENSE_BASES[0]
     buf.writeAscii(base, "RKPD")
-    // PID = 0 gives friend code based on MD5("JCMR") checksum
-    buf.writeUInt32BE(base + PID_OFFSET, 0L)
+    // Use a PID value other than `0L`
+    buf.writeUInt32BE(base + PID_OFFSET, 1L)
 
     val info = RksysParser.parse(buf)
     val friendCode = info.licenses[0].friendCode


### PR DESCRIPTION
On new licenses, Wheel Witch currently displays a friend code `2147-4836-4800`, even though this corresponds to `profileId = 0`. The game itself shows an empty friend code field, and this PR aims to do the same by not displaying the friend code in this case.