### PR TITLE
fix(save): show local VR values instead of leaderboard VR

### DIFF
--- a/app/src/main/java/com/skiletro/wheelwitch/model/SaveFileInfo.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/model/SaveFileInfo.kt
@@ -30,6 +30,7 @@ data class LicenseInfo(
   val vr: Int? = null,
   val raceWins: Int? = null,
   val raceLosses: Int? = null,
+  val ratingVr: Int? = null,
   val miiDataBase64: String? = null,
   val leaderboardVr: Int? = null,
   val firsts: Int? = null,

--- a/app/src/main/java/com/skiletro/wheelwitch/ui/components/LicenseGrid.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/ui/components/LicenseGrid.kt
@@ -132,7 +132,7 @@ fun PopulatedCell(license: LicenseInfo, scoreResult: ScoreResult?, badge: Vanity
         )
       }
       Spacer(modifier = Modifier.height(3.dp))
-      val vr = license.leaderboardVr ?: 0
+      val vr = license.ratingVr ?: license.vr ?: 0
       Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
           text = "VR ",

--- a/app/src/main/java/com/skiletro/wheelwitch/viewmodel/SaveDataViewModel.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/viewmodel/SaveDataViewModel.kt
@@ -285,13 +285,14 @@ class SaveDataViewModel(
               .awaitAll()
           }
         val validReads = parsed.filterNotNull()
-        val infos = validReads.mapNotNull { it.info?.let { info -> it.region to info } }.toMap()
+        val rawInfos = validReads.mapNotNull { it.info?.let { info -> it.region to info } }.toMap()
         val hasSaves = validReads.associate { it.region to it.hasSave }
+        ratingVrMap = loadRatingVrMap(tree)
+        val infos = populateRatingVr(ratingVrMap, rawInfos)
         _saveInfos.value = infos
         _hasSave.value = hasSaves
         _hasAnySave.value = computeHasAnySave(tree)
         _hasRRSave.value = computeHasRRSave(tree)
-        ratingVrMap = loadRatingVrMap(tree)
         val target = pickSelectedRegion(regions)
         if (target != _selectedRegion.value) {
           _selectedRegion.value = target
@@ -624,6 +625,19 @@ class SaveDataViewModel(
     val file = tree.pulsarRrDir?.findFile("RRRating.pul") ?: return emptyMap()
     val bytes = readDolphinBytes(tree.resolver, file) ?: return emptyMap()
     return RRRatingParser.parse(bytes).associate { it.profileId.toLong() to it.vr }
+  }
+
+  private fun populateRatingVr(
+    ratingVrMap: Map<Long, Float>,
+    infos: Map<Region, SaveFileInfo>
+  ): Map<Region, SaveFileInfo> {
+    return infos.mapValues { (_, saveFile) ->
+      SaveFileInfo(saveFile.licenses.map { license ->
+        license.copy(
+          ratingVr = ratingVrMap[license.profileId]?.let { (it * 100).toInt() }
+        )
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
Currently, Wheel Witch shows the leaderboard VR values for the licenses. The problem with this is that users might think that their saves have been properly imported, even though their local VR values might actually be wrong. This PR changes the VR to be displayed based on the parsed `RRRating.pul` and, alternatively, the `rksys.dat`. The leaderboard VR fetching is still in the code and can be used in other parts of the UI for future additions – only the `ratingVr` field was added.

As the server never had the most recent VR values anyway, this change should be good to avoid confusion and stay consistent with the in-game values.