### PR TITLE
fix(data): reject zip entries with path traversal components

### DIFF
--- a/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
@@ -251,7 +251,10 @@ class DolphinTree(context: Context, val treeUri: Uri) {
     withContext(Dispatchers.IO) {
       ZipFile(zipFile).use { zip ->
         val entries = zip.entries().toList()
-        val fileEntries = entries.filterNot { it.isDirectory }
+        val fileEntries =
+          entries
+            .filterNot { it.isDirectory }
+            .filter { entry -> entry.name.split('/').none { it == ".." } }
         val filesTotal = fileEntries.size
         val bytesTotal = fileEntries.sumOf { it.size.coerceAtLeast(0L) }
 

--- a/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
@@ -279,7 +279,7 @@ class DolphinTree(context: Context, val treeUri: Uri) {
         var fileIndex = 0
         var bytesDone = 0L
         for (entry in fileEntries) {
-          val currentFile = entry.name
+          val currentFile = ZipSafety.normalizeEntryName(entry.name)
           onProgress(
             ExtractProgress(
               phase = ExtractingPhase.WritingFiles,
@@ -293,9 +293,9 @@ class DolphinTree(context: Context, val treeUri: Uri) {
           val entrySize = entry.size.coerceAtLeast(0L)
           writeZipEntry(
             entry = entry,
-            parent = byPath.getValue(parentParts(entry.name)),
+            parent = byPath.getValue(parentParts(currentFile)),
             getChild = getChild,
-            fileName = entry.name.substringAfterLast('/'),
+            fileName = currentFile.substringAfterLast('/'),
             input = zip.getInputStream(entry),
           )
           bytesDone += entrySize
@@ -321,6 +321,9 @@ class DolphinTree(context: Context, val treeUri: Uri) {
    * each `createDirectory` only needs one IPC call), and returns a
    * map from path parts to the resulting [DocumentFile]. The empty
    * list is included as the key for `packDir` itself.
+   *
+   * The caller is responsible for only providing Zip entries with
+   * safe entry names.
    */
   private fun precreateDirectories(
     fileEntries: List<ZipEntry>,
@@ -336,7 +339,7 @@ class DolphinTree(context: Context, val treeUri: Uri) {
     // pre-pass with "Key [apps] is missing in the map".
     val uniqueParents = fileEntries
       .flatMap { file ->
-        val parts = file.name.split('/').filter { it.isNotEmpty() }
+        val parts = ZipSafety.normalizeEntryName(file.name).split('/')
         (1 until parts.size).map { parts.take(it) }
       }
       .toSet()
@@ -370,8 +373,8 @@ class DolphinTree(context: Context, val treeUri: Uri) {
     return byPath
   }
 
-  private fun parentParts(entryName: String): List<String> {
-    val parts = entryName.split('/').filter { it.isNotEmpty() }
+  private fun parentParts(normalizedEntryName: String): List<String> {
+    val parts = normalizedEntryName.split('/')
     return if (parts.size <= 1) emptyList() else parts.dropLast(1)
   }
 

--- a/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
@@ -10,6 +10,7 @@ import com.skiletro.wheelwitch.R
 import com.skiletro.wheelwitch.data.DolphinTree.Companion.GAME_INI_NOTICE
 import com.skiletro.wheelwitch.model.SemVersion
 import com.skiletro.wheelwitch.util.prefs.Prefs
+import com.skiletro.wheelwitch.util.io.ZipSafety
 import com.skiletro.wheelwitch.util.prefs.PrefsKeys
 import java.io.File
 import java.io.FileOutputStream
@@ -254,7 +255,7 @@ class DolphinTree(context: Context, val treeUri: Uri) {
         val fileEntries =
           entries
             .filterNot { it.isDirectory }
-            .filter { entry -> entry.name.split('/').none { it == ".." } }
+            .filter { ZipSafety.isSafeEntryName(it.name) }
         val filesTotal = fileEntries.size
         val bytesTotal = fileEntries.sumOf { it.size.coerceAtLeast(0L) }
 

--- a/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/DolphinTree.kt
@@ -255,7 +255,7 @@ class DolphinTree(context: Context, val treeUri: Uri) {
         val fileEntries =
           entries
             .filterNot { it.isDirectory }
-            .filter { ZipSafety.isSafeEntryName(it.name) }
+            .filter { ZipSafety.isSafeEntryName(it.name, SaveManager.userDataPathPrefixes) }
         val filesTotal = fileEntries.size
         val bytesTotal = fileEntries.sumOf { it.size.coerceAtLeast(0L) }
 
@@ -681,10 +681,6 @@ class DolphinTree(context: Context, val treeUri: Uri) {
     fileName: String,
     input: InputStream,
   ) {
-    if (SaveManager.userDataPathPrefixes.any { entry.name.startsWith(it) }) {
-      Timber.tag(TAG).d("Skipping user data path: %s", entry.name)
-      return
-    }
     getChild(parent, fileName)?.delete()
     val target =
       parent.createFile("application/octet-stream", fileName)

--- a/app/src/main/java/com/skiletro/wheelwitch/data/SaveManager.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/SaveManager.kt
@@ -640,8 +640,8 @@ object SaveManager {
     tree: DolphinTree,
     entryName: String,
   ): Pair<DocumentFile, String>? {
-    val normalized = entryName.removePrefix("./").trimStart('/')
     if (!ZipSafety.isSafeEntryName(entryName)) return null
+    val normalized = ZipSafety.normalizeEntryName(entryName)
     if (normalized.startsWith("RetroWFC/")) {
       val rest = normalized.removePrefix("RetroWFC/")
       val parts = rest.split('/').filter { it.isNotEmpty() }

--- a/app/src/main/java/com/skiletro/wheelwitch/data/SaveManager.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/data/SaveManager.kt
@@ -9,6 +9,7 @@ import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import com.skiletro.wheelwitch.util.io.ZipSafety
 import timber.log.Timber
 import kotlin.text.startsWith
 
@@ -639,7 +640,8 @@ object SaveManager {
     tree: DolphinTree,
     entryName: String,
   ): Pair<DocumentFile, String>? {
-    val normalized = entryName.trimStart('/')
+    val normalized = entryName.removePrefix("./").trimStart('/')
+    if (!ZipSafety.isSafeEntryName(entryName)) return null
     if (normalized.startsWith("RetroWFC/")) {
       val rest = normalized.removePrefix("RetroWFC/")
       val parts = rest.split('/').filter { it.isNotEmpty() }

--- a/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
@@ -1,0 +1,27 @@
+package com.skiletro.wheelwitch.util.io
+
+/**
+ * Helpers for safe zip entry name handling. Every zip extraction
+ * site in the codebase should validate entry names through these
+ * helpers to prevent path-traversal (Zip Slip) attacks.
+ */
+object ZipSafety {
+
+  /**
+   * Returns `true` when [name] is a safe, relative entry path
+   * suitable for extraction into a target directory.
+   *
+   * Rejected patterns:
+   * - Absolute paths (`/etc/passwd`)
+   * - Parent-directory components (`../escape`, `foo/../../bar`)
+   * - Current-directory components (`./sneaky`, `foo/./bar`)
+   *
+   * A leading `./` prefix is stripped before checking, for
+   * compatibility with zip tools that produce `./foo/bar` entries.
+   */
+  fun isSafeEntryName(name: String): Boolean {
+    val normalized = name.removePrefix("./")
+    return !normalized.startsWith("/") &&
+      normalized.split('/').none { it == ".." || it == "." }
+  }
+}

--- a/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
@@ -15,6 +15,7 @@ object ZipSafety {
    * - Absolute paths (`/etc/passwd`)
    * - Parent-directory components (`../escape`, `foo/../../bar`)
    * - Current-directory components (`./sneaky`, `foo/./bar`)
+   * - Empty components from double slashes (`foo//bar`)
    *
    * A leading `./` prefix is stripped before checking, for
    * compatibility with zip tools that produce `./foo/bar` entries.
@@ -22,6 +23,6 @@ object ZipSafety {
   fun isSafeEntryName(name: String): Boolean {
     val normalized = name.removePrefix("./")
     return !normalized.startsWith("/") &&
-      normalized.split('/').none { it == ".." || it == "." }
+      normalized.split('/').none { it.isEmpty() || it == ".." || it == "." }
   }
 }

--- a/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
@@ -16,13 +16,18 @@ object ZipSafety {
    * - Parent-directory components (`../escape`, `foo/../../bar`)
    * - Current-directory components (`./sneaky`, `foo/./bar`)
    * - Empty components from double slashes (`foo//bar`)
+   * - Paths starting with any prefix in [prefixBlockList]
    *
    * A leading `./` prefix is stripped before checking, for
    * compatibility with zip tools that produce `./foo/bar` entries.
    */
-  fun isSafeEntryName(name: String): Boolean {
+  fun isSafeEntryName(
+    name: String,
+    prefixBlockList: List<String> = emptyList(),
+  ): Boolean {
     val normalized = name.removePrefix("./")
     return !normalized.startsWith("/") &&
-      normalized.split('/').none { it.isEmpty() || it == ".." || it == "." }
+      normalized.split('/').none { it.isEmpty() || it == ".." || it == "." } &&
+      prefixBlockList.none { normalized.startsWith(it) }
   }
 }

--- a/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/io/ZipSafety.kt
@@ -8,6 +8,13 @@ package com.skiletro.wheelwitch.util.io
 object ZipSafety {
 
   /**
+   * Strips a leading `./` prefix.
+   */
+  fun normalizeEntryName(name: String): String {
+    return name.removePrefix("./")
+  }
+
+  /**
    * Returns `true` when [name] is a safe, relative entry path
    * suitable for extraction into a target directory.
    *
@@ -25,7 +32,7 @@ object ZipSafety {
     name: String,
     prefixBlockList: List<String> = emptyList(),
   ): Boolean {
-    val normalized = name.removePrefix("./")
+    val normalized = normalizeEntryName(name)
     return !normalized.startsWith("/") &&
       normalized.split('/').none { it.isEmpty() || it == ".." || it == "." } &&
       prefixBlockList.none { normalized.startsWith(it) }

--- a/app/src/main/java/com/skiletro/wheelwitch/util/mii/MiiWadInstaller.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/mii/MiiWadInstaller.kt
@@ -7,6 +7,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.FileProvider
 import com.skiletro.wheelwitch.data.GameTypeParser
 import com.skiletro.wheelwitch.util.io.FileDownloader
+import com.skiletro.wheelwitch.util.io.ZipSafety
 import com.skiletro.wheelwitch.util.launcher.DolphinLauncher
 import com.skiletro.wheelwitch.util.net.HttpClientProvider
 import timber.log.Timber
@@ -96,6 +97,12 @@ object MiiWadInstaller {
         ZipInputStream(FileInputStream(zipFile)).use { zis ->
             var entry = zis.nextEntry
             while (entry != null) {
+                if (!ZipSafety.isSafeEntryName(entry.name)) {
+                    Timber.w("Skipping unsafe zip entry: %s", entry.name)
+                    zis.closeEntry()
+                    entry = zis.nextEntry
+                    continue
+                }
                 if (!entry.isDirectory && entry.name.endsWith(".wad", ignoreCase = true)) {
                     val outFile = File(destDir, entry.name.substringAfterLast("/"))
                     outFile.outputStream().use { output ->

--- a/app/src/main/java/com/skiletro/wheelwitch/util/mii/MiiWadInstaller.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/mii/MiiWadInstaller.kt
@@ -13,6 +13,7 @@ import com.skiletro.wheelwitch.util.net.HttpClientProvider
 import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
+import java.security.MessageDigest
 import java.util.zip.ZipInputStream
 
 /** Downloads and installs the Mii Channel WAD file for use as a Mii Maker in Dolphin. */
@@ -22,6 +23,8 @@ object MiiWadInstaller {
     private const val WAD_FILE_NAME = "Mii Channel Symbols - HACS.wad"
     private const val ZIP_FILE_NAME = "mii_channel_symbols.zip"
     private const val CACHE_DIR_NAME = "mii_maker"
+    private const val EXPECTED_ZIP_SHA256 =
+        "9fd802a4bd80cda4522817b7e0a95aaa703ad29e6d866156f67bdb86549bb0f6"
 
     /** Returns the cached WAD file from `cache/mii_maker/`, or null if not yet downloaded. */
     fun getCachedWadFile(context: Context): File? {
@@ -48,6 +51,8 @@ object MiiWadInstaller {
             targetFile = zipFile,
             client = HttpClientProvider.largeDownloadClient,
         )
+
+        verifyZipIntegrity(zipFile, EXPECTED_ZIP_SHA256)
 
         val wadFile = extractWad(zipFile, cacheDir)
         zipFile.delete()
@@ -121,5 +126,24 @@ object MiiWadInstaller {
             ?: error("No .wad file found in the archive")
         Timber.tag("MiiWad").d("Extracted WAD: %s", chosen.name)
         return chosen
+    }
+
+    @VisibleForTesting
+    fun verifyZipIntegrity(file: File, expectedHash: String) {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(8192)
+            var bytesRead: Int
+            while (input.read(buffer).also { bytesRead = it } != -1) {
+                digest.update(buffer, 0, bytesRead)
+            }
+        }
+        val actualHash = digest.digest().joinToString("") { "%02x".format(it) }
+        if (!actualHash.equals(expectedHash, ignoreCase = true)) {
+            file.delete()
+            throw SecurityException(
+                "SHA-256 mismatch for ${file.name}: expected $expectedHash, got $actualHash",
+            )
+        }
     }
 }

--- a/app/src/test/java/com/skiletro/wheelwitch/data/DolphinTreeTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/data/DolphinTreeTest.kt
@@ -738,6 +738,12 @@ class DolphinTreeTest {
       zos.putNextEntry(ZipEntry("deep/../../../escape3.txt"))
       zos.write("bad3".encodeToByteArray())
       zos.closeEntry()
+      zos.putNextEntry(ZipEntry("/etc/passwd"))
+      zos.write("abs".encodeToByteArray())
+      zos.closeEntry()
+      zos.putNextEntry(ZipEntry("./sneaky.txt"))
+      zos.write("dot".encodeToByteArray())
+      zos.closeEntry()
     }
 
     val outputs = mutableMapOf<String, ByteArrayOutputStream>()
@@ -746,11 +752,13 @@ class DolphinTreeTest {
     val tree = DolphinTree(context, treeUri)
     tree.extractZipToPack(zip) { /* no-op */ }
 
-    // Only the safe entry was written; traversal entries were filtered out.
+    // Only the safe entry was written; traversal and absolute entries were filtered out.
     assertThat(outputs).containsKey("good.txt")
     assertThat(outputs).doesNotContainKey("escape.txt")
     assertThat(outputs).doesNotContainKey("escape2.txt")
     assertThat(outputs).doesNotContainKey("escape3.txt")
+    assertThat(outputs).doesNotContainKey("passwd")
+    assertThat(outputs).doesNotContainKey("sneaky.txt")
   }
 
   // --- writeLaunchJson / readLaunchJson --------------------------------

--- a/app/src/test/java/com/skiletro/wheelwitch/data/DolphinTreeTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/data/DolphinTreeTest.kt
@@ -719,6 +719,40 @@ class DolphinTreeTest {
     verify(exactly = 0) { pulsarRrDir.createFile(any<String>(), any<String>()) }
   }
 
+  @Test
+  fun `extractZipToPack rejects entries with dot-dot path components`(
+    @TempDir tempDir: Path
+  ) = runBlocking {
+    val (_, packDir, _) = setupDirChain()
+    val zip = File(tempDir.toFile(), "pack.zip")
+    ZipOutputStream(zip.outputStream()).use { zos ->
+      zos.putNextEntry(ZipEntry("good.txt"))
+      zos.write("ok".encodeToByteArray())
+      zos.closeEntry()
+      zos.putNextEntry(ZipEntry("../../escape.txt"))
+      zos.write("bad".encodeToByteArray())
+      zos.closeEntry()
+      zos.putNextEntry(ZipEntry("pack/../../escape2.txt"))
+      zos.write("bad2".encodeToByteArray())
+      zos.closeEntry()
+      zos.putNextEntry(ZipEntry("deep/../../../escape3.txt"))
+      zos.write("bad3".encodeToByteArray())
+      zos.closeEntry()
+    }
+
+    val outputs = mutableMapOf<String, ByteArrayOutputStream>()
+    setupPackEntryWrite(packDir, "good.txt", outputs)
+
+    val tree = DolphinTree(context, treeUri)
+    tree.extractZipToPack(zip) { /* no-op */ }
+
+    // Only the safe entry was written; traversal entries were filtered out.
+    assertThat(outputs).containsKey("good.txt")
+    assertThat(outputs).doesNotContainKey("escape.txt")
+    assertThat(outputs).doesNotContainKey("escape2.txt")
+    assertThat(outputs).doesNotContainKey("escape3.txt")
+  }
+
   // --- writeLaunchJson / readLaunchJson --------------------------------
 
   @Test

--- a/app/src/test/java/com/skiletro/wheelwitch/data/SaveManagerTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/data/SaveManagerTest.kt
@@ -563,6 +563,63 @@ class SaveManagerTest {
     assertThat(summary.ghosts).isEqualTo(0)
   }
 
+  @Test
+  fun `restoreAll skips entries with path traversal and absolute paths`() = runTest {
+    val env = setupBackupEnv(palExists = true)
+    val source = mockk<Uri>(relaxed = true)
+
+    val backupBytes = ByteArrayOutputStream().use { baos ->
+      java.util.zip.ZipOutputStream(baos).use { zos ->
+        val manifest = JSONObject().apply {
+          put("version", SaveManager.BACKUP_FORMAT_VERSION)
+          put("type", SaveManager.BACKUP_TYPE)
+          put("createdAt", System.currentTimeMillis())
+          put("contents", JSONObject().apply {
+            put("retroWfc", org.json.JSONArray(listOf("RMCP")))
+            put("vanillaSaves", org.json.JSONArray())
+            put("patchedIso", false)
+            put("faceLib", false)
+            put("pulsar", org.json.JSONArray())
+            put("ghosts", 0)
+          })
+        }
+        zos.putNextEntry(ZipEntry("manifest.json"))
+        zos.write(manifest.toString().encodeToByteArray())
+        zos.closeEntry()
+        // Safe entry.
+        zos.putNextEntry(ZipEntry("RetroWFC/RMCP/rksys.dat"))
+        zos.write("safe-data".encodeToByteArray())
+        zos.closeEntry()
+        // Traversal entries — should all be skipped.
+        zos.putNextEntry(ZipEntry("../../escape.txt"))
+        zos.write("bad".encodeToByteArray())
+        zos.closeEntry()
+        zos.putNextEntry(ZipEntry("./RetroWFC/RMCP/../../sneaky.dat"))
+        zos.write("bad2".encodeToByteArray())
+        zos.closeEntry()
+        zos.putNextEntry(ZipEntry("/etc/passwd"))
+        zos.write("abs".encodeToByteArray())
+        zos.closeEntry()
+        zos.putNextEntry(ZipEntry("./sneaky.txt"))
+        zos.write("dot".encodeToByteArray())
+        zos.closeEntry()
+      }
+      baos.toByteArray()
+    }
+    every { env.resolver.openInputStream(source) } returns ByteArrayInputStream(backupBytes)
+
+    val result = SaveManager.restoreAll(env.tree, source)
+
+    assertThat(result.isSuccess).isTrue()
+    // Only the safe RetroWFC entry was processed; traversal entries were skipped.
+    val summary = result.getOrThrow()
+    assertThat(summary.rksys).isEqualTo(1)
+    assertThat(summary.vanillaSaves).isEqualTo(0)
+    assertThat(summary.faceLib).isFalse()
+    assertThat(summary.pulsar).isEqualTo(0)
+    assertThat(summary.ghosts).isEqualTo(0)
+  }
+
   // --- deleteRR --------------------------------------------------------
 
   @Test

--- a/app/src/test/java/com/skiletro/wheelwitch/util/io/ZipSafetyTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/util/io/ZipSafetyTest.kt
@@ -59,4 +59,24 @@ class ZipSafetyTest {
   fun `isSafeEntryName rejects leading double slash`() {
     assertThat(ZipSafety.isSafeEntryName("//etc/passwd")).isFalse()
   }
+
+  @Test
+  fun `isSafeEntryName rejects entry matching blocked prefix`() {
+    assertThat(ZipSafety.isSafeEntryName("riivolution/save/RetroWFC/PAL/rksys.dat", listOf("riivolution/save/"))).isFalse()
+  }
+
+  @Test
+  fun `isSafeEntryName accepts entry not matching blocked prefix`() {
+    assertThat(ZipSafety.isSafeEntryName("riivolution/RetroRewind6.xml", listOf("riivolution/save/"))).isTrue()
+  }
+
+  @Test
+  fun `isSafeEntryName accepts entry with dot-slash before blocked prefix`() {
+    assertThat(ZipSafety.isSafeEntryName("./riivolution/save/RetroWFC/PAL/rksys.dat", listOf("riivolution/save/"))).isFalse()
+  }
+
+  @Test
+  fun `isSafeEntryName defaults to empty blocklist`() {
+    assertThat(ZipSafety.isSafeEntryName("anything/goes.txt")).isTrue()
+  }
 }

--- a/app/src/test/java/com/skiletro/wheelwitch/util/io/ZipSafetyTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/util/io/ZipSafetyTest.kt
@@ -49,4 +49,14 @@ class ZipSafetyTest {
   fun `isSafeEntryName rejects absolute path after dot-slash`() {
     assertThat(ZipSafety.isSafeEntryName("./../../escape.txt")).isFalse()
   }
+
+  @Test
+  fun `isSafeEntryName rejects double slash`() {
+    assertThat(ZipSafety.isSafeEntryName("foo//bar.txt")).isFalse()
+  }
+
+  @Test
+  fun `isSafeEntryName rejects leading double slash`() {
+    assertThat(ZipSafety.isSafeEntryName("//etc/passwd")).isFalse()
+  }
 }

--- a/app/src/test/java/com/skiletro/wheelwitch/util/io/ZipSafetyTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/util/io/ZipSafetyTest.kt
@@ -1,0 +1,52 @@
+package com.skiletro.wheelwitch.util.io
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ZipSafetyTest {
+
+  @Test
+  fun `isSafeEntryName accepts simple filename`() {
+    assertThat(ZipSafety.isSafeEntryName("file.txt")).isTrue()
+  }
+
+  @Test
+  fun `isSafeEntryName accepts nested relative path`() {
+    assertThat(ZipSafety.isSafeEntryName("a/b/file.txt")).isTrue()
+  }
+
+  @Test
+  fun `isSafeEntryName accepts dot-slash prefix`() {
+    assertThat(ZipSafety.isSafeEntryName("./a/b/file.txt")).isTrue()
+  }
+
+  @Test
+  fun `isSafeEntryName accepts bare dot-slash filename`() {
+    assertThat(ZipSafety.isSafeEntryName("./sneaky.txt")).isTrue()
+  }
+
+  @Test
+  fun `isSafeEntryName rejects absolute path`() {
+    assertThat(ZipSafety.isSafeEntryName("/etc/passwd")).isFalse()
+  }
+
+  @Test
+  fun `isSafeEntryName rejects parent directory component`() {
+    assertThat(ZipSafety.isSafeEntryName("../../escape.txt")).isFalse()
+  }
+
+  @Test
+  fun `isSafeEntryName rejects parent directory in middle`() {
+    assertThat(ZipSafety.isSafeEntryName("pack/../../escape.txt")).isFalse()
+  }
+
+  @Test
+  fun `isSafeEntryName rejects current directory in middle`() {
+    assertThat(ZipSafety.isSafeEntryName("foo/./bar.txt")).isFalse()
+  }
+
+  @Test
+  fun `isSafeEntryName rejects absolute path after dot-slash`() {
+    assertThat(ZipSafety.isSafeEntryName("./../../escape.txt")).isFalse()
+  }
+}

--- a/app/src/test/java/com/skiletro/wheelwitch/util/mii/MiiWadInstallerTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/util/mii/MiiWadInstallerTest.kt
@@ -87,16 +87,17 @@ class MiiWadInstallerTest {
     }
 
     @Test
-    fun `extractWad extracts only basename from traversal entries`(@TempDir tempDir: Path) {
+    fun `extractWad rejects traversal entries via ZipSafety`(@TempDir tempDir: Path) {
         val zip = File(tempDir.toFile(), "bundle.zip")
         ZipOutputStream(zip.outputStream()).use { zos ->
             zos.putNextEntry(ZipEntry("../../evil.wad"))
             zos.write(byteArrayOf(0x00, 0x00, 0x00, 0x20) + ByteArray(64))
             zos.closeEntry()
         }
-        val extracted = MiiWadInstaller.extractWadForTest(zip, tempDir.toFile())
-        assertThat(extracted.name).isEqualTo("evil.wad")
-        assertThat(extracted.parentFile).isEqualTo(tempDir.toFile())
+        val ex = assertThrows<IllegalStateException> {
+            MiiWadInstaller.extractWadForTest(zip, tempDir.toFile())
+        }
+        assertThat(ex.message).contains("No .wad file found")
     }
 
     @Test

--- a/app/src/test/java/com/skiletro/wheelwitch/util/mii/MiiWadInstallerTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/util/mii/MiiWadInstallerTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Path
+import java.security.MessageDigest
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -112,5 +113,26 @@ class MiiWadInstallerTest {
             }
         }.toByteArray()
         assertThat(payload.size).isGreaterThan(1024)
+    }
+
+    @Test
+    fun `verifyZipIntegrity accepts matching hash`(@TempDir tempDir: Path) {
+        val file = File(tempDir.toFile(), "test.bin")
+        file.writeBytes(byteArrayOf(0x01, 0x02, 0x03, 0x04))
+        val hash = MessageDigest.getInstance("SHA-256").digest(file.readBytes())
+            .joinToString("") { "%02x".format(it) }
+        MiiWadInstaller.verifyZipIntegrity(file, hash)
+        assertThat(file.exists()).isTrue()
+    }
+
+    @Test
+    fun `verifyZipIntegrity rejects mismatched hash and deletes file`(@TempDir tempDir: Path) {
+        val file = File(tempDir.toFile(), "test.bin")
+        file.writeBytes(byteArrayOf(0x01, 0x02, 0x03, 0x04))
+        val ex = assertThrows<SecurityException> {
+            MiiWadInstaller.verifyZipIntegrity(file, "0000000000000000000000000000000000000000000000000000000000000000")
+        }
+        assertThat(ex.message).contains("SHA-256 mismatch")
+        assertThat(file.exists()).isFalse()
     }
 }

--- a/app/src/test/java/com/skiletro/wheelwitch/util/mii/MiiWadInstallerTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/util/mii/MiiWadInstallerTest.kt
@@ -87,6 +87,19 @@ class MiiWadInstallerTest {
     }
 
     @Test
+    fun `extractWad extracts only basename from traversal entries`(@TempDir tempDir: Path) {
+        val zip = File(tempDir.toFile(), "bundle.zip")
+        ZipOutputStream(zip.outputStream()).use { zos ->
+            zos.putNextEntry(ZipEntry("../../evil.wad"))
+            zos.write(byteArrayOf(0x00, 0x00, 0x00, 0x20) + ByteArray(64))
+            zos.closeEntry()
+        }
+        val extracted = MiiWadInstaller.extractWadForTest(zip, tempDir.toFile())
+        assertThat(extracted.name).isEqualTo("evil.wad")
+        assertThat(extracted.parentFile).isEqualTo(tempDir.toFile())
+    }
+
+    @Test
     fun `zip roundtrip preserves payload bytes`(@TempDir tempDir: Path) {
         val payload = ByteArrayOutputStream().also { baos ->
             ZipOutputStream(baos).use { zos ->


### PR DESCRIPTION
Filter out any zip entry whose name contains a ".." path component during pack extraction, preventing writes outside the target packDir.

Closes #37.
