### PR TITLE
refactor(pack): remove 3.x.x version guard from update logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ The sub-packages under `util/` are intentional. Keep new files in the right sub-
 - **Leaderboard**: clickable rows with 5dp primary border on focus; one-shot `hasRequestedFocus` guard for pagination
 - **File downloads**: `FileDownloader.downloadToFile()` with progress callback, HTTP validation, configurable client
 - **Mii Maker WAD**: downloads zip from GameBanana, extracts `.wad`, launches via `ACTION_VIEW` + FileProvider
-- **Update server**: see `VersionFileParser.RR_BASE`; version/deletion manifest files; fallback to full reinstall if < `RewindPackManager.MIN_INCREMENTAL_VERSION`
+- **Update server**: see `VersionFileParser.RR_BASE`; version/deletion manifest files; full reinstall when no local version exists
 - **Copy buffer**: 262144 bytes; **Parallel incremental downloads** via `async/await`
 - **Multi-region saves**: `SaveManager.Region` enum (PAL/USA/JPN) mapped from the ROM filename prefix; one save file per region
 
@@ -95,7 +95,6 @@ All values live in code. This table maps each thing to its canonical source.
 | Display name | `DolphinLauncher.DISPLAY_NAME` |
 | ROM extensions | `DolphinLauncher.ROM_EXTENSIONS` |
 | Riivolution XML default | `DolphinLauncher.DEFAULT_XML_REL_PATH` |
-| Min reinstall version | `RewindPackManager.MIN_INCREMENTAL_VERSION` |
 | Update server host | `VersionFileParser.RR_BASE` |
 | API host | `VersionFileParser.RWFC_API` |
 | Badges host | `VersionFileParser.BADGES_BASE` |
@@ -104,7 +103,7 @@ All values live in code. This table maps each thing to its canonical source.
 | Version filename | `DolphinTree.VERSION_FILE_NAME` |
 | Metadata XML filename | `DolphinTree.METADATA_XML_NAME` |
 
-## Tests (~273 tests)
+## Tests (~272 tests)
 
 ### Stack
 JUnit 5, MockK 1.13.x, Truth 1.4.x, `org.json:json` test dep (Android stubs throw "not mocked")
@@ -138,7 +137,7 @@ JUnit 5, MockK 1.13.x, Truth 1.4.x, `org.json:json` test dep (Android stubs thro
 | `data/DolphinConfigTest.kt` | 25 | `IsoPaths.toIniLines`, `read`/`upsert`/`remove`, idempotency, comment preservation, `dolphinUserTreeUri` |
 | `data/SaveManagerTest.kt` | 9 | region mapping, `listRegions`, `hasSave`/`backup`/`restore`/`delete` |
 | `network/VersionFileParserTest.kt` | 17 | update/deletion parsing, leaderboard, health, tracks, race stats |
-| `domain/RewindPackManagerTest.kt` | 12 | `checkStatus`, `installLatest` (zip + extract + version-after-extract, server failures, extract-failure no-version-write), `update` (incremental vs full reinstall fallback) |
+| `domain/RewindPackManagerTest.kt` | 11 | `checkStatus`, `installLatest` (zip + extract + version-after-extract, server failures, extract-failure no-version-write), `update` (incremental steps) |
 | `viewmodel/PackUpdateViewModelTest.kt` | 10 | init/checkStatus/install/update/clearError state machine |
 | `viewmodel/SaveDataViewModelTest.kt` | 12 | refresh, region selection, slot selection, leaderboard merge, backup/restore/delete delegation |
 

--- a/app/src/main/java/com/skiletro/wheelwitch/domain/RewindPackManager.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/domain/RewindPackManager.kt
@@ -104,9 +104,7 @@ class RewindPackManager(
    * Performs the smallest set of incremental updates that takes the
    * local pack from its current version to the server's latest
    * version. Falls back to a full reinstall if the local version is
-   * missing or older than [MIN_INCREMENTAL_VERSION]. The pack format
-   * changed incompatibly around that point, so partial updates are
-   * not safe.
+   * missing (e.g. first install or corrupted state).
    *
    * Same `Dispatchers.IO` wrapper as [installLatest]. See the kdoc
    * there for why.
@@ -116,12 +114,9 @@ class RewindPackManager(
       runCatching {
         val local = tree.readVersion()
         val server = VersionFileParser.fetchServerInfo().getOrThrow()
-        val minVersion =
-          SemVersion.parse(MIN_INCREMENTAL_VERSION)
-            ?: error("Invalid MIN_INCREMENTAL_VERSION constant")
-        if (local == null || local < minVersion) {
+        if (local == null) {
           Timber.tag(TAG)
-            .i("Local version %s is below %s; doing full reinstall", local, minVersion)
+            .i("Local version missing; doing full reinstall")
           performInstall(VersionFileParser.getFullZipUrl(), onProgress)
         } else {
           val steps =
@@ -270,9 +265,6 @@ class RewindPackManager(
     )
 
   private companion object {
-    /** Local versions older than this get a full reinstall, not an incremental update. */
-    const val MIN_INCREMENTAL_VERSION = "3.2.6"
-
     /** Cached pack zip filename inside [Context.getCacheDir]. */
     const val PACK_ZIP_NAME = "RetroRewind.zip"
 

--- a/app/src/main/java/com/skiletro/wheelwitch/viewmodel/PackUpdateViewModel.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/viewmodel/PackUpdateViewModel.kt
@@ -164,10 +164,9 @@ class PackUpdateViewModel(
 
   /**
    * Performs the smallest set of incremental updates needed. Falls
-   * back to a full reinstall if the local version is missing or
-   * predates the pack format change. Same [installMutex] guard as
-   * [installLatest]; calling both in parallel is a no-op for the
-   * second caller.
+   * back to a full reinstall if the local version is missing.
+   * Same [installMutex] guard as [installLatest]; calling both in
+   * parallel is a no-op for the second caller.
    */
   fun update() {
     viewModelScope.launch {

--- a/app/src/test/java/com/skiletro/wheelwitch/domain/RewindPackManagerTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/domain/RewindPackManagerTest.kt
@@ -354,41 +354,7 @@ class RewindPackManagerTest {
   }
 
   @Test
-  fun `update falls back to full reinstall when local version is below 3_2_6`() = runBlocking {
-    coEvery { tree.readVersion() } returns SemVersion(3, 2, 0) andThen null
-    val server = serverInfo()
-    every { VersionFileParser.fetchServerInfo() } returns Result.success(server)
-    every { VersionFileParser.getFullZipUrl() } returns "https://example.com/full.zip"
-    every { FileDownloader.downloadToFile(any(), any(), any(), any(), any(), any()) } answers
-      {
-        val target = it.invocation.args[1] as File
-        target.parentFile?.mkdirs()
-        target.writeBytes(byteArrayOf(0x00))
-        target
-      }
-    coEvery { tree.extractZipToPack(any(), any()) } returns Unit
-    coEvery { tree.writeVersion(server.latestVersion) } returns Unit
-    coEvery { tree.writeRrMetadata(server.latestVersion) } returns Unit
-
-    val result = manager().update { /* no-op */ }
-
-    assertThat(result.isSuccess).isTrue()
-    verify(exactly = 1) {
-      FileDownloader.downloadToFile(
-        url = "https://example.com/full.zip",
-        targetFile = any(),
-        onProgress = any(),
-        client = any(),
-        maxRetries = any(),
-        initialBackoffMillis = any(),
-      )
-    }
-    coVerify(exactly = 1) { tree.writeVersion(server.latestVersion) }
-    coVerify(exactly = 1) { tree.writeRrMetadata(server.latestVersion) }
-  }
-
-  @Test
-  fun `update applies incremental steps when local is at or above 3_2_6`() = runBlocking {
+  fun `update applies incremental steps when local version exists`() = runBlocking {
     coEvery { tree.readVersion() } returns SemVersion(3, 3, 0) andThen null
     val server =
       ServerInfo(


### PR DESCRIPTION
Wheel Witch did not exist when Retro Rewind was at v3.x.x, so `MIN_INCREMENTAL_VERSION` (in theory) can never be triggered.
Simplify the update path to only fall back to full reinstall when no local version exists.
Closes #13 
