### PR TITLE
feat(settings): add log viewer screen for bug reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ All values live in code. This table maps each thing to its canonical source.
 | Version filename | `DolphinTree.VERSION_FILE_NAME` |
 | Metadata XML filename | `DolphinTree.METADATA_XML_NAME` |
 
-## Tests (~272 tests)
+## Tests
 
 ### Stack
 JUnit 5, MockK 1.13.x, Truth 1.4.x, `org.json:json` test dep (Android stubs throw "not mocked")
@@ -126,6 +126,7 @@ JUnit 5, MockK 1.13.x, Truth 1.4.x, `org.json:json` test dep (Android stubs thro
 | `util/log/LogBufferTest.kt` | 6 | capacity, wrap-around, clear, snapshot ordering |
 | `util/log/MemoryBufferTreeTest.kt` | 4 | fan-out to buffer, minPriority filtering |
 | `util/log/AppReleaseLogTreeTest.kt` | 2 | drops INFO/DEBUG/VERBOSE, keeps WARN/ERROR/ASSERT |
+| `util/log/LogTextRendererTest.kt` | 8 | line parsing (level letters, plain lines, messageStart), colourised report preserves text + per-level span colours |
 | `util/io/OptionalFileTreeTest.kt` | 9 | enable/disable, file append, 1MB rotation |
 | `util/io/FileDownloaderTest.kt` | 6 | MockWebServer HTTP flows, backoff, 4xx/5xx discrimination |
 | `util/io/ByteReaderTest.kt` | 12 | byte-level reads, endianness, bounds |
@@ -140,6 +141,7 @@ JUnit 5, MockK 1.13.x, Truth 1.4.x, `org.json:json` test dep (Android stubs thro
 | `domain/RewindPackManagerTest.kt` | 11 | `checkStatus`, `installLatest` (zip + extract + version-after-extract, server failures, extract-failure no-version-write), `update` (incremental steps) |
 | `viewmodel/PackUpdateViewModelTest.kt` | 10 | init/checkStatus/install/update/clearError state machine |
 | `viewmodel/SaveDataViewModelTest.kt` | 12 | refresh, region selection, slot selection, leaderboard merge, backup/restore/delete delegation |
+| `viewmodel/LogViewerViewModelTest.kt` | 4 | init load, loading state, reload, copy bumps trigger |
 
 ### Testability notes
 - Pure functions tested directly (no Android deps): SemVersion, parseRooms(), parseUpdatesText(), `DolphinConfig`, `DolphinPaths.physicalRoot`, `DolphinLauncher.buildLaunchJson`, etc.

--- a/app/src/main/java/com/skiletro/wheelwitch/ui/screens/LogViewerScreen.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/ui/screens/LogViewerScreen.kt
@@ -1,0 +1,183 @@
+package com.skiletro.wheelwitch.ui.screens
+
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skiletro.wheelwitch.R
+import com.skiletro.wheelwitch.ui.components.ScreenHeader
+import com.skiletro.wheelwitch.ui.theme.buttonShape
+import com.skiletro.wheelwitch.ui.theme.surfaceShape
+import com.skiletro.wheelwitch.util.launcher.BugReportLauncher
+import com.skiletro.wheelwitch.util.log.LogTextRenderer
+import com.skiletro.wheelwitch.util.log.LogViewerColors
+import com.skiletro.wheelwitch.util.log.logViewerColorsFor
+import com.skiletro.wheelwitch.viewmodel.LogViewerViewModel
+import kotlinx.coroutines.launch
+
+/**
+ * Bug Report screen: read-only view of the in-memory + on-disk logs in
+ * the same chronological order as the exported `.log` file, with copy
+ * and multi-target share actions.
+ *
+ * The log text comes from [LogViewerViewModel] (rendered via
+ * `LogExporter.exportToString`), so what the user reads is exactly what
+ * the "share as file" option attaches. The screen reloads the snapshot
+ * on every open via a [LaunchedEffect], so it reflects log entries
+ * captured since the last visit.
+ */
+@Composable
+fun LogViewerScreen(
+  viewModel: LogViewerViewModel,
+  onClose: () -> Unit,
+) {
+  val state by viewModel.state.collectAsState()
+  val context = LocalContext.current
+  val scope = rememberCoroutineScope()
+  val copiedMessage = stringResource(R.string.log_viewer_copied_to_clipboard)
+  val logColors = logViewerColors()
+  val coloredLogText = remember(state.logText) { LogTextRenderer.colorizeLogReport(state.logText, logColors) }
+
+  BackHandler(onBack = onClose)
+
+  LaunchedEffect(Unit) { viewModel.reload() }
+
+  LaunchedEffect(state.copyRequest) {
+    if (state.copyRequest > 0L) {
+      Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
+    }
+  }
+
+  Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+    Column(modifier = Modifier.fillMaxSize()) {
+      ScreenHeader(
+        title = stringResource(R.string.log_viewer_title),
+        onBack = onClose,
+        trailing = {
+          IconButton(onClick = { viewModel.copyToClipboard() }) {
+            Icon(
+              imageVector = ImageVector.vectorResource(R.drawable.ic_content_copy),
+              contentDescription = stringResource(R.string.cd_copy),
+              tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        },
+      )
+
+      Box(
+        modifier = Modifier.fillMaxWidth().weight(1f).padding(horizontal = 16.dp),
+      ) {
+        if (state.isLoading) {
+          CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        } else {
+          SelectionContainer(modifier = Modifier.fillMaxSize()) {
+            Text(
+              text = coloredLogText,
+              fontFamily = FontFamily.Monospace,
+              fontSize = 13.sp,
+              lineHeight = 18.sp,
+              color = MaterialTheme.colorScheme.onSurface,
+              modifier =
+                Modifier.fillMaxSize()
+                  .background(MaterialTheme.colorScheme.surfaceVariant, surfaceShape)
+                  .verticalScroll(rememberScrollState())
+                  .padding(12.dp),
+            )
+          }
+        }
+      }
+
+      Row(
+        modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Spacer(modifier = Modifier.weight(1f))
+        ShareOptionButton(
+          icon = ImageVector.vectorResource(R.drawable.ic_share),
+          label = stringResource(R.string.log_viewer_share_text),
+          onClick = { BugReportLauncher.shareText(context, state.logText) },
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        ShareOptionButton(
+          icon = ImageVector.vectorResource(R.drawable.ic_attach_file),
+          label = stringResource(R.string.log_viewer_share_file),
+          onClick = { scope.launch { BugReportLauncher.launch(context) } },
+        )
+      }
+    }
+  }
+}
+
+/** Tonal share button with a leading icon, matching the settings Report button style. */
+@Composable
+private fun ShareOptionButton(
+  icon: ImageVector,
+  label: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Button(
+    onClick = onClick,
+    modifier = modifier,
+    shape = buttonShape,
+    contentPadding = ButtonDefaults.TextButtonContentPadding,
+    colors =
+      ButtonDefaults.filledTonalButtonColors(
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+      ),
+  ) {
+    Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(18.dp))
+    Spacer(modifier = Modifier.width(8.dp))
+    Text(label)
+  }
+}
+
+/**
+ * Resolves the [LogViewerColors] used to render the report from the active
+ * Material scheme. Plain/metadata pass through theme-adaptive roles; the
+ * level colours come from [logViewerColorsFor], which picks light/dark-tuned
+ * logcat hues (gray, blue, green, orange, red).
+ */
+@Composable
+private fun logViewerColors(): LogViewerColors {
+  val scheme = MaterialTheme.colorScheme
+  return logViewerColorsFor(
+    surface = scheme.surfaceVariant,
+    onSurface = scheme.onSurface,
+    onSurfaceVariant = scheme.onSurfaceVariant,
+  )
+}

--- a/app/src/main/java/com/skiletro/wheelwitch/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/ui/screens/MainScreen.kt
@@ -23,6 +23,7 @@ import com.skiletro.wheelwitch.ui.theme.AppTheme
 import com.skiletro.wheelwitch.ui.theme.ThemeMode
 import com.skiletro.wheelwitch.util.prefs.Prefs
 import com.skiletro.wheelwitch.util.prefs.PrefsKeys
+import com.skiletro.wheelwitch.viewmodel.LogViewerViewModel
 import com.skiletro.wheelwitch.viewmodel.MiiMakerViewModel
 import com.skiletro.wheelwitch.viewmodel.OnlineViewModel
 import com.skiletro.wheelwitch.viewmodel.PackUpdateViewModel
@@ -41,6 +42,7 @@ fun MainScreen(
   miiMaker: MiiMakerViewModel = viewModel(),
   onlineViewModel: OnlineViewModel = viewModel(),
   saveData: SaveDataViewModel = viewModel(factory = SaveDataViewModel.factory(packUpdate)),
+  logViewer: LogViewerViewModel = viewModel(factory = LogViewerViewModel.Factory),
   appTheme: AppTheme = AppTheme.Hex,
   onChangeAppTheme: (AppTheme) -> Unit = {},
   themeMode: ThemeMode = ThemeMode.System,
@@ -53,9 +55,14 @@ fun MainScreen(
   }
 
   var showSettings by remember { mutableStateOf(false) }
+  var showLogViewer by remember { mutableStateOf(false) }
 
   BackHandler(enabled = showSettings) {
     showSettings = false
+  }
+
+  BackHandler(enabled = showLogViewer) {
+    showLogViewer = false
   }
 
   Box(Modifier.fillMaxSize()) {
@@ -81,7 +88,7 @@ fun MainScreen(
         }
 
         AnimatedVisibility(
-          visible = showSettings,
+          visible = showSettings && !showLogViewer,
           enter = slideInVertically() + fadeIn(),
           exit = slideOutVertically() + fadeOut(),
         ) {
@@ -90,6 +97,7 @@ fun MainScreen(
             miiMaker = miiMaker,
             saveData = saveData,
             onClose = { showSettings = false },
+            onOpenLogViewer = { showLogViewer = true },
             appTheme = appTheme,
             onChangeAppTheme = onChangeAppTheme,
             themeMode = themeMode,
@@ -102,6 +110,17 @@ fun MainScreen(
               onboardingComplete = false
               showSettings = false
             },
+          )
+        }
+
+        AnimatedVisibility(
+          visible = showLogViewer,
+          enter = slideInVertically() + fadeIn(),
+          exit = slideOutVertically() + fadeOut(),
+        ) {
+          LogViewerScreen(
+            viewModel = logViewer,
+            onClose = { showLogViewer = false },
           )
         }
       } else {

--- a/app/src/main/java/com/skiletro/wheelwitch/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/ui/screens/SettingsScreen.kt
@@ -49,7 +49,6 @@ import com.skiletro.wheelwitch.ui.components.SettingsItem
 import com.skiletro.wheelwitch.ui.theme.AppTheme
 import com.skiletro.wheelwitch.ui.theme.ThemeMode
 import com.skiletro.wheelwitch.ui.theme.buttonShape
-import com.skiletro.wheelwitch.util.launcher.BugReportLauncher
 import com.skiletro.wheelwitch.util.mii.MiiFaceCache
 import com.skiletro.wheelwitch.util.prefs.Prefs
 import com.skiletro.wheelwitch.util.prefs.PrefsKeys
@@ -81,6 +80,7 @@ fun SettingsScreen(
   miiMaker: MiiMakerViewModel,
   saveData: SaveDataViewModel,
   onClose: () -> Unit,
+  onOpenLogViewer: () -> Unit,
   appTheme: AppTheme,
   onChangeAppTheme: (AppTheme) -> Unit,
   themeMode: ThemeMode,
@@ -165,7 +165,7 @@ fun SettingsScreen(
         )
       }
       item { PackSection(packUpdate = packUpdate) }
-      item { LoggingSection() }
+      item { LoggingSection(onOpenLogViewer = onOpenLogViewer) }
       item {
         AdvancedSection(
           onRelaunchOnboarding = onRelaunchOnboarding,
@@ -649,9 +649,9 @@ private fun MiiMakerSection(
   )
 }
 
-/** Logging section: toggle the on-disk log file and launch the bug-report chooser. */
+/** Logging section: toggle the on-disk log file and open the Log Viewer. */
 @Composable
-private fun LoggingSection() {
+private fun LoggingSection(onOpenLogViewer: () -> Unit) {
   val context = LocalContext.current
   val loggingPrefs = remember { Prefs.main(context) }
   SettingsCategoryHeader(stringResource(R.string.settings_logging))
@@ -678,7 +678,7 @@ private fun LoggingSection() {
     summary = stringResource(R.string.settings_report_bug_sub),
     trailing = {
       Button(
-        onClick = { BugReportLauncher.launch(context) },
+        onClick = onOpenLogViewer,
         shape = buttonShape,
         contentPadding = ButtonDefaults.TextButtonContentPadding,
         colors = ButtonDefaults.filledTonalButtonColors(

--- a/app/src/main/java/com/skiletro/wheelwitch/util/launcher/BugReportLauncher.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/launcher/BugReportLauncher.kt
@@ -41,10 +41,28 @@ object BugReportLauncher {
   }
 
   /**
+   * Shares [text] via the system chooser without an attachment. Used by
+   * the Log Viewer "share as text" option (e.g. Discord, email). Falls
+   * back to [copyToClipboard] + a toast when no share target exists.
+   * Returns true when the chooser was launched.
+   */
+  fun shareText(context: Context, text: String): Boolean {
+    val send = buildTextIntent(context, text)
+    val chooser = Intent.createChooser(send, context.getString(R.string.bug_report_chooser_title))
+    chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    return runCatching { context.startActivity(chooser); true }
+      .getOrElse {
+        copyToClipboard(context, text)
+        Toast.makeText(context, R.string.bug_report_share_failed, Toast.LENGTH_LONG).show()
+        false
+      }
+  }
+
+  /**
    * Copies [text] to the system clipboard under a [ClipData] labeled
    * with the app name, so paste targets can identify its source.
    */
-  private fun copyToClipboard(context: Context, text: String) {
+  fun copyToClipboard(context: Context, text: String) {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
     clipboard?.setPrimaryClip(ClipData.newPlainText(context.getString(R.string.app_name), text))
   }
@@ -68,6 +86,20 @@ object BugReportLauncher {
       putExtra(Intent.EXTRA_TEXT, body)
       putExtra(Intent.EXTRA_STREAM, uri)
       addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+  }
+
+  private fun buildTextIntent(context: Context, text: String): Intent {
+    val subject = context.getString(
+      R.string.bug_report_subject,
+      BuildConfig.VERSION_NAME,
+      BuildConfig.GIT_HASH,
+    )
+    return Intent(Intent.ACTION_SEND).apply {
+      type = "text/plain"
+      putExtra(Intent.EXTRA_EMAIL, arrayOf(BuildConfig.LOGS_EMAIL))
+      putExtra(Intent.EXTRA_SUBJECT, subject)
+      putExtra(Intent.EXTRA_TEXT, text)
     }
   }
 

--- a/app/src/main/java/com/skiletro/wheelwitch/util/log/LogExporter.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/log/LogExporter.kt
@@ -36,6 +36,12 @@ object LogExporter {
     return file
   }
 
+  /**
+   * Returns the report text without writing a file, so the Log Viewer
+   * screen can show exactly what [flushToCacheFile] would export.
+   */
+  fun exportToString(context: Context): String = buildReport(context)
+
   /** Builds the report text. Exposed for tests so they can assert the format. */
   internal fun buildReport(context: Context): String {
     val sb = StringBuilder()

--- a/app/src/main/java/com/skiletro/wheelwitch/util/log/LogTextRenderer.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/util/log/LogTextRenderer.kt
@@ -1,0 +1,137 @@
+package com.skiletro.wheelwitch.util.log
+
+import android.util.Log
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+
+/**
+ * Parses the plain-text report produced by [LogExporter.buildReport] into
+ * per-line segments so the Log Viewer screen can render it with per-level
+ * colours, and colorizes it into an [AnnotatedString].
+ *
+ * Every captured log line (in-memory and on-disk) shares the shape
+ * `<timestamp> <LEVEL>/<tag>: <message>`; header lines, section markers,
+ * empty lines, and Timber stack-trace continuation lines don't match and are
+ * treated as plain.
+ */
+object LogTextRenderer {
+  private val LOG_LINE_REGEX = Regex("^\\d+ ([VDIWEA?])/([^:]*): ")
+
+  /**
+   * Returns the [Log] priority for [label] (a single log-level letter), or
+   * [Log.INFO] for unknown levels so `?` lines still render as normal text.
+   */
+  internal fun levelForLabel(label: String): Int =
+      when (label) {
+        "V" -> Log.VERBOSE
+        "D" -> Log.DEBUG
+        "I" -> Log.INFO
+        "W" -> Log.WARN
+        "E" -> Log.ERROR
+        "A" -> Log.ASSERT
+        else -> Log.INFO
+      }
+
+  /**
+   * Splits [text] into one [LogLine] per line, preserving order and content
+   * exactly (the concatenation of [LogLine.text] with `\n` separators equals
+   * [text]).
+   */
+  fun parseLogLines(text: String): List<LogLine> {
+    val rawLines = text.lineSequence().toList()
+    val lines =
+        if (text.endsWith('\n') && rawLines.isNotEmpty()) rawLines.dropLast(1) else rawLines
+    return lines.map { line ->
+      val match = LOG_LINE_REGEX.find(line)
+      if (match == null) {
+        LogLine(line, PLAIN_LEVEL, messageStart = -1)
+      } else {
+        LogLine(line, levelForLabel(match.groupValues[1]), messageStart = match.range.last + 1)
+      }
+    }
+  }
+
+  /**
+   * Renders [text] as an [AnnotatedString] with per-line colours: log lines
+   * get their timestamp/level/tag prefix in [LogViewerColors.metadata] and the
+   * message in its level colour; plain lines use [LogViewerColors.plain]. The
+   * resulting string content is identical to [text].
+   */
+  fun colorizeLogReport(text: String, colors: LogViewerColors): AnnotatedString {
+    val annotated = AnnotatedString.Builder()
+    val lines = parseLogLines(text)
+    val trailingNewline = text.endsWith('\n')
+    for ((index, line) in lines.withIndex()) {
+      if (line.messageStart < 0) {
+        annotated.pushStyle(SpanStyle(color = colors.plain))
+        annotated.append(line.text)
+        annotated.pop()
+      } else {
+        annotated.pushStyle(SpanStyle(color = colors.metadata))
+        annotated.append(line.text, 0, line.messageStart)
+        annotated.pop()
+        annotated.pushStyle(SpanStyle(color = colors.colorForLevel(line.level)))
+        annotated.append(line.text, line.messageStart, line.text.length)
+        annotated.pop()
+      }
+      if (trailingNewline || index < lines.lastIndex) annotated.append('\n')
+    }
+    return annotated.toAnnotatedString()
+  }
+}
+
+/** One line of the log report. [level] is an android.util.Log priority, [PLAIN_LEVEL] for plain lines. */
+data class LogLine(val text: String, val level: Int, val messageStart: Int)
+
+/** Level for lines that are not captured log entries (headers, markers, stack-trace continuations). */
+const val PLAIN_LEVEL = -1
+
+/**
+ * Theme-independent palette for [LogTextRenderer.colorizeLogReport]. The
+ * Log Viewer resolves the concrete values from the active Material theme via
+ * [logViewerColorsFor]; tests construct it with fixed colours.
+ */
+data class LogViewerColors(
+  val plain: Color,
+  val metadata: Color,
+  val verbose: Color,
+  val debug: Color,
+  val info: Color,
+  val warn: Color,
+  val error: Color,
+) {
+  fun colorForLevel(level: Int): Color =
+      when (level) {
+        Log.VERBOSE -> verbose
+        Log.DEBUG -> debug
+        Log.INFO -> info
+        Log.WARN -> warn
+        else -> error
+      }
+}
+
+/**
+ * Resolves a [LogViewerColors] readable on [surface]. Verbose, debug, info,
+ * warn and error use classic logcat hues (gray, blue, green, orange, red)
+ * tuned to the surface's lightness so they stay distinguishable on both
+ * light and dark themes; plain and metadata pass through the theme-adaptive
+ * roles.
+ */
+fun logViewerColorsFor(
+  surface: Color,
+  onSurface: Color,
+  onSurfaceVariant: Color,
+): LogViewerColors {
+  val isDark = surface.luminance() < 0.5f
+  return LogViewerColors(
+    plain = onSurface,
+    metadata = onSurfaceVariant,
+    verbose = if (isDark) Color(0xFFBDBDBD) else Color(0xFF9E9E9E),
+    debug = if (isDark) Color(0xFF64B5F6) else Color(0xFF1565C0),
+    info = if (isDark) Color(0xFF81C784) else Color(0xFF2E7D32),
+    warn = if (isDark) Color(0xFFFFB300) else Color(0xFFE65100),
+    error = if (isDark) Color(0xFFEF5350) else Color(0xFFC62828),
+  )
+}

--- a/app/src/main/java/com/skiletro/wheelwitch/viewmodel/LogViewerViewModel.kt
+++ b/app/src/main/java/com/skiletro/wheelwitch/viewmodel/LogViewerViewModel.kt
@@ -1,0 +1,89 @@
+package com.skiletro.wheelwitch.viewmodel
+
+import android.app.Application
+import android.content.Context
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.lifecycle.viewModelScope
+import com.skiletro.wheelwitch.util.launcher.BugReportLauncher
+import com.skiletro.wheelwitch.util.log.LogExporter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** UI state for the [LogViewerViewModel]. */
+@Immutable
+data class LogViewerUiState(
+  val isLoading: Boolean = true,
+  val logText: String = "",
+  val copyRequest: Long = 0L,
+)
+
+/**
+ * Owns the log-viewer state for the bug-report flow.
+ *
+ * [logText] is the full report rendered by [LogExporter.exportToString]
+ * — the same text the "share as file" option exports — so the user
+ * reads exactly what gets sent. [copyRequest] is incremented on every
+ * copy so the screen can re-trigger its snackbar for repeated copies.
+ *
+ * Tests can swap the [logLoader], [clipboard], and [ioDispatcher] to
+ * inject fakes without touching [LogExporter] / the clipboard service.
+ */
+class LogViewerViewModel(
+  application: Application,
+  private val logLoader: suspend (Context) -> String = { LogExporter.exportToString(it) },
+  private val clipboard: (String) -> Unit = { text -> BugReportLauncher.copyToClipboard(application, text) },
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : AndroidViewModel(application) {
+  private val app = application
+
+  private val _state = MutableStateFlow(LogViewerUiState())
+  val state: StateFlow<LogViewerUiState> = _state.asStateFlow()
+
+  init {
+    reload()
+  }
+
+  /**
+   * (Re-)renders the log report into [state]. Called from [init] and
+   * again whenever the Log Viewer screen opens, so the snapshot is
+   * fresh after new log entries have been captured.
+   */
+  fun reload() {
+    viewModelScope.launch {
+      _state.value = _state.value.copy(isLoading = true)
+      val text = withContext(ioDispatcher) { logLoader(app) }
+      _state.value = _state.value.copy(isLoading = false, logText = text)
+    }
+  }
+
+  /** Copies the full log text to the clipboard and bumps [LogViewerUiState.copyRequest]. */
+  fun copyToClipboard() {
+    clipboard(state.value.logText)
+    _state.value = _state.value.copy(copyRequest = _state.value.copyRequest + 1)
+  }
+
+  companion object {
+    /**
+     * [ViewModelProvider.Factory] for the composition root. The default
+     * [ViewModelProvider] for [AndroidViewModel] only handles a single
+     * `(Application)` constructor, so the injected [logLoader] /
+     * [clipboard] parameters require a custom factory.
+     */
+    val Factory: ViewModelProvider.Factory = viewModelFactory {
+      initializer {
+        val app =
+          this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as Application
+        LogViewerViewModel(app)
+      }
+    }
+  }
+}

--- a/app/src/main/res/drawable/ic_attach_file.xml
+++ b/app/src/main/res/drawable/ic_attach_file.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <group android:translateY="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M720-330q0 104-73 177T470-80q-104 0-177-73t-73-177v-370q0-75 52.5-127.5T400-880q75 0 127.5 52.5T580-700v350q0 46-32 78t-78 32q-46 0-78-32t-32-78v-330q0-17 11.5-28.5T400-720q17 0 28.5 11.5T440-680v330q0 13 8.5 21.5T470-320q13 0 21.5-8.5T500-350v-350q-1-42-29.5-71T400-800q-42 0-71 29t-29 71v370q-1 71 49 120.5T470-160q70 0 119-49.5T640-330v-350q0-17 11.5-28.5T680-720q17 0 28.5 11.5T720-680v350Z"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_content_copy.xml
+++ b/app/src/main/res/drawable/ic_content_copy.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <group android:translateY="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360ZM200-80q-33 0-56.5-23.5T120-160v-520q0-17 11.5-28.5T160-720q17 0 28.5 11.5T200-680v520h400q17 0 28.5 11.5T640-120q0 17-11.5 28.5T600-80H200Z"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <group android:translateY="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M680-80q-50 0-85-35t-35-85q0-6 3-28L282-392q-16 15-37 23.5t-45 8.5q-50 0-85-35t-35-85q0-50 35-85t85-35q24 0 45 8.5t37 23.5l281-164q-2-7-2.5-13.5T560-760q0-50 35-85t85-35q50 0 85 35t35 85q0 50-35 85t-85 35q-24 0-45-8.5T598-672L317-508q2 7 2.5 13.5t.5 14.5q0 8-.5 14.5T317-452l281 164q16-15 37-23.5t45-8.5q50 0 85 35t35 85q0 50-35 85t-85 35Z"/>
+  </group>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -273,4 +273,12 @@
     <string name="bug_report_summary_with_error">Most recent error in the log buffer: %1$s</string>
     <string name="bug_report_summary_no_error">No errors captured in the current log buffer.</string>
     <string name="bug_report_share_failed">No app available to send the bug report. Logs have been copied to the clipboard.</string>
+
+    <!-- log viewer -->
+    <string name="log_viewer_title">Bug Report</string>
+    <string name="log_viewer_share">Share</string>
+    <string name="log_viewer_share_text">Share as text</string>
+    <string name="log_viewer_share_file">Share as file</string>
+    <string name="log_viewer_copied_to_clipboard">Logs copied to clipboard</string>
+    <string name="cd_copy">Copy logs</string>
 </resources>

--- a/app/src/test/java/com/skiletro/wheelwitch/util/log/LogTextRendererTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/util/log/LogTextRendererTest.kt
@@ -1,0 +1,139 @@
+package com.skiletro.wheelwitch.util.log
+
+import android.util.Log
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class LogTextRendererTest {
+
+  private val colors =
+      LogViewerColors(
+        plain = Color.Red,
+        metadata = Color.Blue,
+        verbose = Color.Gray,
+        debug = Color.Cyan,
+        info = Color.Green,
+        warn = Color.Yellow,
+        error = Color.Magenta,
+      )
+
+  @Test
+  fun `parse classifies each log level letter`() {
+    val lines =
+        LogTextRenderer.parseLogLines(
+            "0 V/V: v\n" + "1 D/D: d\n" + "2 I/I: i\n" + "3 W/W: w\n" + "4 E/E: e\n" + "5 A/A: a\n"
+        )
+    assertThat(lines.map { it.level })
+        .containsExactly(Log.VERBOSE, Log.DEBUG, Log.INFO, Log.WARN, Log.ERROR, Log.ASSERT)
+        .inOrder()
+  }
+
+  @Test
+  fun `parse treats unknown level letter as info`() {
+    val lines = LogTextRenderer.parseLogLines("0 ?/T: odd\n")
+    assertThat(lines.single().level).isEqualTo(Log.INFO)
+  }
+
+  @Test
+  fun `parse marks header marker and stack-trace lines as plain`() {
+    val lines =
+        LogTextRenderer.parseLogLines(
+            "Wheel Witch v1.0 (build 1, git=abc)\n" +
+                "1700000000000 I/T: started\n" +
+                "  at com.foo.Bar.baz(Bar.kt:1)\n" +
+                "--- on-disk log: wheelwitch.log ---\n" +
+                "1700000000001 E/T: boom\n"
+        )
+    assertThat(lines.map { it.level })
+        .containsExactly(PLAIN_LEVEL, Log.INFO, PLAIN_LEVEL, PLAIN_LEVEL, Log.ERROR)
+        .inOrder()
+    assertThat(lines.filter { it.level == PLAIN_LEVEL }.all { it.messageStart == -1 }).isTrue()
+  }
+
+  @Test
+  fun `parse messageStart points past the metadata prefix`() {
+    val line = "1700000000000 I/Tag: hello world"
+    val parsed = LogTextRenderer.parseLogLines(line).single()
+    assertThat(parsed.text).isEqualTo(line)
+    assertThat(parsed.text.substring(parsed.messageStart)).isEqualTo("hello world")
+  }
+
+  @Test
+  fun `colorize preserves the exact input text`() {
+    val text =
+        "Wheel Witch v1.0 (build 1, git=abc)\n" +
+            "1700000000000 V/V: verbose\n" +
+            "  at com.foo.Bar.baz(Bar.kt:1)\n" +
+            "--- on-disk log: wheelwitch.log ---\n" +
+            "1700000000001 E/T: boom\n"
+    assertThat(LogTextRenderer.colorizeLogReport(text, colors).text).isEqualTo(text)
+  }
+
+  @Test
+  fun `colorize preserves input that does not end in a newline`() {
+    val text = "1700000000000 I/T: no trailing newline"
+    assertThat(LogTextRenderer.colorizeLogReport(text, colors).text).isEqualTo(text)
+  }
+
+  @Test
+  fun `colorize applies plain color to header and metadata dimming to log lines`() {
+    val text = "header\n1700000000000 W/Tag: warn me"
+    val annotated = LogTextRenderer.colorizeLogReport(text, colors)
+
+    assertThat(spanColorAt(annotated, text.indexOf("header"))).isEqualTo(Color.Red)
+    assertThat(spanColorAt(annotated, text.indexOf("1700000000000 W/Tag:"))).isEqualTo(Color.Blue)
+    assertThat(spanColorAt(annotated, text.indexOf("warn me"))).isEqualTo(Color.Yellow)
+  }
+
+  @Test
+  fun `colorize maps every level to its colour`() {
+    val text =
+        "0 V/V: verbose\n" +
+            "1 D/D: debug\n" +
+            "2 I/I: info\n" +
+            "3 W/W: warn\n" +
+            "4 E/E: error\n" +
+            "5 A/A: assert\n"
+    val annotated = LogTextRenderer.colorizeLogReport(text, colors)
+    assertThat(spanColorAt(annotated, text.indexOf("verbose"))).isEqualTo(Color.Gray)
+    assertThat(spanColorAt(annotated, text.indexOf("debug"))).isEqualTo(Color.Cyan)
+    assertThat(spanColorAt(annotated, text.indexOf("info"))).isEqualTo(Color.Green)
+    assertThat(spanColorAt(annotated, text.indexOf("warn"))).isEqualTo(Color.Yellow)
+    assertThat(spanColorAt(annotated, text.indexOf("error"))).isEqualTo(Color.Magenta)
+    assertThat(spanColorAt(annotated, text.indexOf("assert"))).isEqualTo(Color.Magenta)
+  }
+
+  @Test
+  fun `logViewerColorsFor picks light-tuned logcat hues on light surfaces`() {
+    val colors = logViewerColorsFor(Color.White, Color.DarkGray, Color.Gray)
+    assertThat(colors.verbose).isEqualTo(Color(0xFF9E9E9E))
+    assertThat(colors.debug).isEqualTo(Color(0xFF1565C0))
+    assertThat(colors.info).isEqualTo(Color(0xFF2E7D32))
+    assertThat(colors.warn).isEqualTo(Color(0xFFE65100))
+    assertThat(colors.error).isEqualTo(Color(0xFFC62828))
+  }
+
+  @Test
+  fun `logViewerColorsFor picks dark-tuned logcat hues on dark surfaces`() {
+    val colors = logViewerColorsFor(Color.Black, Color.White, Color.LightGray)
+    assertThat(colors.verbose).isEqualTo(Color(0xFFBDBDBD))
+    assertThat(colors.debug).isEqualTo(Color(0xFF64B5F6))
+    assertThat(colors.info).isEqualTo(Color(0xFF81C784))
+    assertThat(colors.warn).isEqualTo(Color(0xFFFFB300))
+    assertThat(colors.error).isEqualTo(Color(0xFFEF5350))
+  }
+
+  @Test
+  fun `logViewerColorsFor passes through theme-adaptive roles`() {
+    val colors = logViewerColorsFor(Color.Black, Color.White, Color.LightGray)
+    assertThat(colors.plain).isEqualTo(Color.White)
+    assertThat(colors.metadata).isEqualTo(Color.LightGray)
+  }
+
+  private fun spanColorAt(annotated: AnnotatedString, index: Int): Color {
+    val range = annotated.spanStyles.first { it.start <= index && index < it.end }
+    return range.item.color
+  }
+}

--- a/app/src/test/java/com/skiletro/wheelwitch/viewmodel/LogViewerViewModelTest.kt
+++ b/app/src/test/java/com/skiletro/wheelwitch/viewmodel/LogViewerViewModelTest.kt
@@ -1,0 +1,106 @@
+package com.skiletro.wheelwitch.viewmodel
+
+import android.app.Application
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LogViewerViewModelTest {
+
+  private val app: Application = mockk(relaxed = true)
+
+  @BeforeEach
+  fun setUp() {
+    // viewModelScope uses Dispatchers.Main.immediate; provide an
+    // UnconfinedTestDispatcher so launched coroutines run on the
+    // calling thread (synchronously inside the test).
+    Dispatchers.setMain(UnconfinedTestDispatcher())
+  }
+
+  @AfterEach
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  private fun viewModel(
+    logLoader: suspend (Context) -> String,
+    clipboard: (String) -> Unit = {},
+    ioDispatcher: CoroutineDispatcher = UnconfinedTestDispatcher(),
+  ) =
+    LogViewerViewModel(
+      application = app,
+      logLoader = logLoader,
+      clipboard = clipboard,
+      ioDispatcher = ioDispatcher,
+    )
+
+  // --- init / reload ---------------------------------------------------
+
+  @Test
+  fun `init loads the log text into state`() = runTest {
+    val vm = viewModel(logLoader = { "Wheel Witch v1.0.0\nI/Tag: hello" })
+
+    assertThat(vm.state.value.isLoading).isFalse()
+    assertThat(vm.state.value.logText).contains("Wheel Witch v1.0.0")
+    assertThat(vm.state.value.logText).contains("I/Tag: hello")
+  }
+
+  @Test
+  fun `state stays loading until the loader completes`() = runTest {
+    val gate = CompletableDeferred<String>()
+    val vm =
+      LogViewerViewModel(
+        application = app,
+        logLoader = { gate.await() },
+        ioDispatcher = UnconfinedTestDispatcher(testScheduler),
+      )
+
+    // The loader is suspended waiting on the gate, so the initial
+    // snapshot still reports the in-flight loading state.
+    assertThat(vm.state.value.isLoading).isTrue()
+
+    gate.complete("loaded")
+
+    assertThat(vm.state.value.isLoading).isFalse()
+    assertThat(vm.state.value.logText).isEqualTo("loaded")
+  }
+
+  @Test
+  fun `reload refreshes the log text from the loader`() = runTest {
+    var text = "first snapshot"
+    val vm = viewModel(logLoader = { text })
+
+    assertThat(vm.state.value.logText).isEqualTo("first snapshot")
+
+    text = "second snapshot"
+    vm.reload()
+
+    assertThat(vm.state.value.logText).isEqualTo("second snapshot")
+  }
+
+  // --- copyToClipboard -------------------------------------------------
+
+  @Test
+  fun `copyToClipboard writes the text and bumps the copy trigger`() = runTest {
+    val copied = mutableListOf<String>()
+    val vm = viewModel(logLoader = { "log text" }, clipboard = { copied += it })
+    val before = vm.state.value.copyRequest
+
+    vm.copyToClipboard()
+
+    assertThat(copied).containsExactly("log text")
+    assertThat(vm.state.value.copyRequest).isEqualTo(before + 1)
+  }
+}

--- a/justfile
+++ b/justfile
@@ -31,6 +31,13 @@ install: build
     echo "Launching com.skiletro.wheelwitch/.MainActivity..."
     adb shell am start -n com.skiletro.wheelwitch.debug/com.skiletro.wheelwitch.MainActivity
 
+run: install
+    #!/usr/bin/env bash
+    sleep 2
+    echo "Getting pid..."
+    PID=$(adb shell pidof -s com.skiletro.wheelwitch.debug) || exit
+    adb logcat --pid $PID -v color
+
 # run unit tests
 test:
     ./gradlew testDebugUnitTest


### PR DESCRIPTION
Closes #30

Still need to think of a better colour scheme for the log viewer, but it's in a decent state at the moment.

<img width="1190" height="658" alt="image" src="https://github.com/user-attachments/assets/126355a3-5768-4ea7-9153-4a2ab2c1df0a" />
